### PR TITLE
Test for scope insertion; copyedit of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lain.js
 
-Lain is an in-memory data store whose structure is composed at run-time. It is most suitable for applications that are composed incrementally with extremely loose-coupling and many external modules.
+Lain is an in-memory data store whose structure is composed at run-time. It is most suitable for applications that are composed incrementally with extremely loose coupling and many external modules.
 
 It acts as tree of observable scopes. Instead of relying on functional or lexical scopes inherent to a programming language, Lain lets you create a scope hierarchy on the fly. This allows the simple creation of component or module-based scopes.
 
@@ -23,7 +23,7 @@ Each of these scopes can hold named instances of the `Data` class.
 
 ```javascript
 
-var country = appScope.data('country'); // returns an empty instance of class Data
+var country = appScope.data('country'); // returns an empty instance of class `Data`
 country.write('Japan'); // stores the string 'Japan'
 
 ```
@@ -32,7 +32,7 @@ Grab a reference to a `Data` instance in the current scope with the `grab` metho
 
 ```javascript
 
-var sameCountry = appScope.grab('country'); // returns the Data instance containing 'Japan'
+var sameCountry = appScope.grab('country'); // returns the `Data` instance containing 'Japan'
 
 ```
 
@@ -52,12 +52,12 @@ Scopes can override `Data` instances, blocking access to `Data` of the same name
 
 pageScope.data('country').write('Russia');
 appScope.data('country').write('Argentina');
-buttonScope.find('country').read(); // returns 'Russia' since pageScope is found before the appScope
+buttonScope.find('country').read(); // returns 'Russia' since `pageScope` is found before `appScope`
 buttonScope.find('country').write('France'); // can overwrite the stored value
 
 ```
 
-The default Data instance allows read and write access from its local and descendant scopes.
+The default `Data` instance allows read and write access from its local and descendant scopes.
 
 ```javascript
 
@@ -84,7 +84,7 @@ States can only be updated in their local scope and are read-only from lower sco
 ```javascript
 
 pageScope.find('url').write('cat.html'); // updates successfully
-menuScope.find('url').write('cat.html'); // throws an Error since it is read-only from the child scope
+menuScope.find('url').write('cat.html'); // throws an error since it is read-only from the child scope
 
 
 ```
@@ -97,7 +97,7 @@ pageScope.find('navigate').write('bunny'); // updates subscribers
 
 menuScope.find('url').read(); // returns 'cat.html'
 
-// peek() returns the last Packet instance
+// `peek()` returns the last `Packet` instance
 // {msg: 'cat.html', topic: null, source: 'url', timestamp: Date.now()}
 
 menuScope.find('url').peek();
@@ -107,7 +107,7 @@ menuScope.find('navigate').peek(); // returns `null`
 
 ```
 
-Every Data instance can treated as a discrete value or as a full pub/sub channel with subscriptions or values available by topic (via the `subscribe` method).
+Every `Data` instance can treated as a discrete value or as a full pub/sub channel with subscriptions or values available by topic (via the `subscribe` method).
 
 ```javascript
 
@@ -130,7 +130,7 @@ The `follow` method acts just like `subscribe` but will also emit the current st
 
 ```javascript
 
-// the callback here is invoked immediately with the stored value and the last stored Packet
+// the callback here is invoked immediately with the stored value and the last stored packet
 fields.follow('animal', function(msg, packet){
     console.log(msg, packet.topic);
 };
@@ -162,27 +162,27 @@ appScope.data('color').write('red');
 appScope.data('shadow').write('blue');
 appScope.data('mixture').write('purple');
 
-pageScope.valves(['color','shadow'); // allows access to only 'color' and 'shadow' `Data` from lower scopes
+pageScope.valves(['color','shadow']); // allows access to only 'color' and 'shadow' `Data` from lower scopes
 
 pageScope.find('color'); // returns the `Data` instance containing 'red'
 pageScope.find('mixture'); // returns the `Data` instance containing 'purple'
 
 buttonScope.find('color'); // returns the `Data` instance containing 'red'
-buttonScope.find('mixture'); // returns null due to the valves in pageScope
+buttonScope.find('mixture'); // returns `null` due to the valves in `pageScope`
 
 
 ```
 
-To create parallel hierarchies of data with the same inherent structure but different access properties (useful for separating things like source file information, styles, api methods, etc.), scopes can declare that Data elements reside in a specific dimension (like a namespace of sorts). Valves can be defined separately for each dimension.
+To create parallel hierarchies of data with the same inherent structure but different access properties (useful for separating things like source file information, styles, api methods, etc.), scopes can declare that `Data`` elements reside in a specific dimension (like a namespace of sorts). Valves can be defined separately for each dimension.
 
 ```javascript
 
-// this returns an appScope instance that accesses data stored in a 'style' namespace
+// this returns an `appScope` instance that accesses data stored in a 'style' namespace
 var styles = appScope.dimension('style');
 
 styles.data('shadow').write('blue');
 
-buttonScope.find('shadow'); // returns null
+buttonScope.find('shadow'); // returns `null`
 buttonScope.dimension('style').find('shadow'); // returns the `Data` instance containing 'blue'
 
 
@@ -192,24 +192,24 @@ Valves can be configured separately for each dimension, allowing flexible white-
 
 ```javascript
 
-// this returns an appScope instance that accesses data stored in a 'style' namespace
+// this returns an `appScope` instance that accesses data stored in a 'style' namespace
 var styles = appScope.dimension('style');
 
 styles.data('background').write('red');
 styles.data('shadow').write('blue');
 styles.data('mixture').write('purple');
 
-buttonScope.find('shadow'); // returns null
+buttonScope.find('shadow'); // returns `null`
 buttonScope.dimension('style').find('shadow'); // returns the `Data` instance containing 'blue'
 
 
-pageScope.valves(['color','shadow'); // allows access to only 'color' and 'shadow' `Data` from lower scopes
+pageScope.valves(['color','shadow']); // allows access to only 'color' and 'shadow' `Data` from lower scopes
 
 pageScope.find('color'); // returns the `Data` instance containing 'red'
 pageScope.find('mixture'); // returns the `Data` instance containing 'purple'
 
 buttonScope.find('color'); // returns the `Data` instance containing 'red'
-buttonScope.find('mixture'); // returns null due to the valves in pageScope
+buttonScope.find('mixture'); // returns `null` due to the valves in `pageScope`
 
 
 ```
@@ -229,7 +229,7 @@ Create a `Scope` from Lain (which is the root `Scope`) or another `Scope` using 
 
 #### Methods
 
-* `createChild([name])` Create a new child scope. The name property is just cosmetic (for debugging).
+* `createChild([name])` Create a new child scope. The `name` property is just cosmetic (for debugging).
 * `children()` Returns an array (shallow copy) of child scopes.
 * `clear()` Destroys all elements and children within the scope, effectively resetting it.
 * `destroy()` Destroys the scope and everything within it.
@@ -246,11 +246,11 @@ the destructible's destroy (or dispose) method will be called. An alternate dest
 
 * `insertParent(scope)` Inserts a scope between this scope and its parent scope.
 * `setParent(scope)` Assigns a parent scope to the current scope, removing its original parent (if any).
-Scopes can be orphan via setParent(null).
+Scopes can be orphaned via `setParent(null)`.
 * `flatten([dimension])` Creates a hash of all `Data` instances accessible to the current scope.
 * `localDataSet([dimension])` Creates a hash of all `Data` instances in the current scope. (NOT YET IMPLEMENTED)
 * `findDataSet(names, [dimension])` Creates a hash of `Data` instances found through the current scope using the given names.
-* `readDataSet(names, [dimension])` Like findDataSet -- but returns the message values instead of the `Data` instances.
+* `readDataSet(names, [dimension])` Like `findDataSet()`—but returns the message values instead of the `Data` instances.
 * `dimension([name])` Returns the current scope with a wrapper accessing the specified dimension as its default.
 
 
@@ -261,23 +261,23 @@ Each topic maintains a list of listeners/subscribers that can receive updates wh
 
 #### Methods
 
-* `read([topic])` Returns the last `msg` written to the topic (or `undefined` if never used).
+* `read([topic])` Returns the last `msg` value written to the topic (or `undefined` if never used).
 * `write(msg, [topic])` Write a `msg` value to be stored (on the topic if specified). This will immediately notify any subscribers.
-* `toggle([topic])` Toggles the boolean `msg` value of the instance (writing `!msg`).
+* `toggle([topic])` Toggles the Boolean `msg` value of the instance (writing `!msg`).
 * `refresh([topic])` Notifies all subscribers of the current `msg` value.
 * `subscribe(watcher, [topic])` Subscribes to the `Data` instance. `watcher` can be a function or object with a `tell` method like `function(msg, packet)`.
 * `follow(watcher, [topic])` Subscribes and immediately emits the current `msg` and `packet` values if present.
 * `monitor(watcher)` Subscribes to all topics on the `Data` instance (including topics added later).
 * `name()` Returns the instance name
 * `dimension()` Returns the dimension (defaults to 'data')
-* `dead()` Returns true if the instance has been destroyed.
+* `dead()` Returns `true` if the instance has been destroyed.
 * `destroy()` Removes and destroys the instance and its subscriptions
 
 
 ### Class: Packet
 
 All writes made against `Data` instances are stored and/or emitted as both a `Packet` envelope and the original value of the write message
- itself (the 'msg' property in the `Packet`). The full `Packet` can be inspected using the `Data.peek` method. It is also sent as the second argument
+ itself (the `msg` property in the `Packet`). The full `Packet` can be inspected using the `Data.peek` method. It is also sent as the second argument
   of all subscription callbacks.
 
 #### Properties
@@ -285,13 +285,13 @@ All writes made against `Data` instances are stored and/or emitted as both a `Pa
 * `msg` Message content written to a `Data` instance.
 * `topic` Subscription topic that created the packet (the default is `null`).
 * `source` Name of the `Data` instance that stored or emitted the packet.
-* `timestamp` Date.now() when created.
+* `timestamp` `Date.now()` when created.
 
 
 
 
 ## License
-Copyright (c) 2016 Scott Southworth & Contributors
+Copyright (c) 2017 Scott Southworth & Contributors
 Licensed under the Apache 2.0 license.
 
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ buttonScope.find('mixture'); // returns `null` due to the valves in `pageScope`
 
 ```
 
-To create parallel hierarchies of data with the same inherent structure but different access properties (useful for separating things like source file information, styles, api methods, etc.), scopes can declare that `Data`` elements reside in a specific dimension (like a namespace of sorts). Valves can be defined separately for each dimension.
+To create parallel hierarchies of data with the same inherent structure but different access properties (useful for separating things like source file information, styles, api methods, etc.), scopes can declare that `Data` elements reside in a specific dimension (like a namespace of sorts). Valves can be defined separately for each dimension.
 
 ```javascript
 

--- a/test/lain_test.js
+++ b/test/lain_test.js
@@ -266,6 +266,31 @@ describe('Lain', function(){
 
     });
 
+    it('can insert a scope', function(){
+
+        world.clear();
+
+        var region = world.createChild();
+        var city1 = world.createChild();
+
+        city1.insertParent(region);
+
+        var d0 = world.data('ergo');
+        var d1 = region.data('ergo');
+        var d2 = city1.data('proxy');
+
+        d0.write('0');
+        d1.write('1');
+        d2.write('2');
+
+        var f1 = region.find('ergo');
+        var f2 = city1.find('ergo');
+
+        assert.equal(f1.read(), '1');
+        assert.equal(f2.read(), '1');
+
+    });
+
     it('can write transactions via multiWrite', function(){
 
         resetLog();


### PR DESCRIPTION
I wrote a test using 'moe', 'larry', and 'shemp', but changed it to 'ergo' and 'proxy'.

It was tough on me to destooge, but my desire to extend the logic in as clean a way as possible won out over my love of not entirely straightfaced example code.